### PR TITLE
Logout tests

### DIFF
--- a/tests/without-login.spec.js
+++ b/tests/without-login.spec.js
@@ -67,7 +67,7 @@ test.describe.serial("Without login", () => {
         await page.waitForTimeout(latency);
     });
 
-    test("test to go my profile", async ({ page }) => {
+    test("can't access the profile page", async ({ page }) => {
         await page.getByRole("button", { name: "Logout" }).click();
         await page.waitForTimeout(latency);
         await page
@@ -78,7 +78,7 @@ test.describe.serial("Without login", () => {
         await page.waitForTimeout(latency);
     });
 
-    test("check a create button invisible", async ({ page }) => {
+    test("create button invisible of main page", async ({ page }) => {
         await page.getByRole("button", { name: "Logout" }).click();
         await page.waitForTimeout(latency);
         await expect(page.locator('[data-dioxus-id="12"]')).not.toBeVisible();
@@ -117,7 +117,7 @@ test.describe.serial("Without login", () => {
         await page.waitForTimeout(latency);
     });
 
-    test("check the proposal create button invisible", async ({ page }) => {
+    test("proposal create button invisible of DAO page", async ({ page }) => {
         await page.getByRole("button", { name: "Logout" }).click();
         await page.waitForTimeout(latency);
         await page.getByPlaceholder("Search").click();

--- a/tests/without-login.spec.js
+++ b/tests/without-login.spec.js
@@ -1,0 +1,138 @@
+import { test, expect } from "@playwright/test";
+import {
+    image_path,
+    latency,
+    agit_name,
+    collection_name,
+    nft_name,
+} from "./constants";
+import path from "path";
+
+test.describe.serial("Without login", () => {
+    test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.waitForTimeout(latency);
+    });
+
+    test("go to collection list", async ({ page }) => {
+        await page.getByRole("button", { name: "Logout" }).click();
+        await page.waitForTimeout(latency);
+        await page.getByRole("link", { name: "Collection" }).click();
+        await page.waitForTimeout(latency);
+    });
+    
+
+    test("search a agit", async ({ page }) => {
+        await page.getByRole("button", { name: "Logout" }).click();
+        await page.waitForTimeout(latency);
+        await page.getByPlaceholder("Search").click();
+        await page.fill('[placeholder="Search"]','logout test');
+        await page.waitForTimeout(latency);
+        await page.press('[placeholder="Search"]', 'Enter');
+        await page.waitForTimeout(latency);
+        // await page.getByText('Agit').click();
+        await page.locator('[data-node-hydration="18"]').click();
+        await page.waitForTimeout(latency);
+        await page.getByText('logout test').first().click();
+        await page.waitForTimeout(latency);
+    });
+
+    test("search a collection", async ({ page }) => {
+        await page.getByRole("button", { name: "Logout" }).click();
+        await page.waitForTimeout(latency);
+        await page.getByPlaceholder("Search").click();
+        await page.fill('[placeholder="Search"]','logout test');
+        await page.waitForTimeout(latency);
+        await page.press('[placeholder="Search"]', 'Enter');
+        await page.waitForTimeout(latency);
+        // await page.getByText('Collection').click();
+        await page.locator('[data-node-hydration="21"]').click();
+        await page.waitForTimeout(latency);
+        await page.getByText('logout test').first().click();
+        await page.waitForTimeout(latency);
+    });
+
+    test("search a NFT", async ({ page }) => {
+        await page.getByRole("button", { name: "Logout" }).click();
+        await page.waitForTimeout(latency);
+        await page.getByPlaceholder("Search").click();
+        await page.fill('[placeholder="Search"]','logout test');
+        await page.waitForTimeout(latency);
+        await page.press('[placeholder="Search"]', 'Enter');
+        await page.waitForTimeout(latency);
+        // await page.getByText('NFT').click();
+        await page.locator('[data-node-hydration="24"]').click();
+        await page.waitForTimeout(latency);
+        await page.getByText('logout test').first().click();
+        await page.waitForTimeout(latency);
+    });
+
+    test("test to go my profile", async ({ page }) => {
+        await page.getByRole("button", { name: "Logout" }).click();
+        await page.waitForTimeout(latency);
+        await page
+        .locator('xpath=//*[@id="main"]/div[1]/div[4]/header/div/div[2]/div')
+        .click();
+        await page.waitForTimeout(latency);
+        await expect(page.locator('body')).toContainText('Connect wallet');
+        await page.waitForTimeout(latency);
+    });
+
+    test("check a create button invisible", async ({ page }) => {
+        await page.getByRole("button", { name: "Logout" }).click();
+        await page.waitForTimeout(latency);
+        await expect(page.locator('[data-dioxus-id="12"]')).not.toBeVisible();
+        await page.waitForTimeout(latency);
+    });
+
+    test("go to collection list of agit", async ({ page }) => {
+        await page.getByRole("button", { name: "Logout" }).click();
+        await page.waitForTimeout(latency);
+        await page.getByPlaceholder("Search").click();
+        await page.fill('[placeholder="Search"]','logout test');
+        await page.waitForTimeout(latency);
+        await page.press('[placeholder="Search"]', 'Enter');
+        await page.waitForTimeout(latency);
+                // await page.getByText('Agit').click();
+        await page.locator('[data-node-hydration="18"]').click();
+        await page.waitForTimeout(latency);
+        await page.getByText('logout test').first().click();
+        await page.waitForTimeout(latency);
+    });
+
+    test("go to DAO list of agit", async ({ page }) => {
+        await page.getByRole("button", { name: "Logout" }).click();
+        await page.waitForTimeout(latency);
+        await page.getByPlaceholder("Search").click();
+        await page.fill('[placeholder="Search"]','logout test');
+        await page.waitForTimeout(latency);
+        await page.press('[placeholder="Search"]', 'Enter');
+        await page.waitForTimeout(latency);
+        // await page.getByText('Agit').click();
+        await page.locator('[data-node-hydration="18"]').click();
+        await page.waitForTimeout(latency);
+        await page.getByText('logout test').first().click();
+        await page.waitForTimeout(latency);
+        await page.getByText('DAO').click();
+        await page.waitForTimeout(latency);
+    });
+
+    test("check the proposal create button invisible", async ({ page }) => {
+        await page.getByRole("button", { name: "Logout" }).click();
+        await page.waitForTimeout(latency);
+        await page.getByPlaceholder("Search").click();
+        await page.fill('[placeholder="Search"]','logout test');
+        await page.waitForTimeout(latency);
+        await page.press('[placeholder="Search"]', 'Enter');
+        await page.waitForTimeout(latency);
+        // await page.getByText('Agit').click();
+        await page.locator('[data-node-hydration="18"]').click();
+        await page.waitForTimeout(latency);
+        await page.getByText('logout test').first().click();
+        await page.waitForTimeout(latency);
+        await page.getByText('DAO').click();
+        await page.waitForTimeout(latency);
+        await expect(page.getByText('Create Proposal')).not.toBeVisible();
+        await page.waitForTimeout(latency);
+    });
+});


### PR DESCRIPTION
After logout tests
1. go to collection list
2. search a agit
3. search a collection
4. search a NFT
5. can't access the profile page
6. create button invisible of main page
7. go to collection list of agit (not available)
8. go to DAO list of agit (not available)
9. proposal create button invisible of DAO page (not available)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 로그인 없이 웹 애플리케이션의 기능을 검증하는 자동화 테스트 추가
	- 로그아웃 버튼 클릭 후 컬렉션 목록으로의 탐색 기능 테스트
	- 다양한 엔티티(아지트, 컬렉션, NFT)에 대한 검색 기능 테스트
	- 인증되지 않은 사용자가 프로필 페이지에 접근할 수 없는지 테스트
	- 로그아웃 상태에서 생성 버튼이 보이지 않는지 확인
	- 아지트를 검색한 후 DAO 목록으로의 탐색 기능 테스트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->